### PR TITLE
Fix endpoint bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ linspace(ndarray([], [5]), 2, 3);
 // => ndarray([2, 2.25, 2.5, 2.75, 3])
 
 linspace(ndarray([], [5]), 2, 3, {endpoint: false});
-// => ndarray([2, 2.25, 2.5, 2.75])
+// => ndarray([2, 2.2, 2.4, 2.6, 2.8])
 
-linspace(ndarray([], [2, 2]), 0, 1)
+linspace(ndarray([], [2, 2]), 0, 1);
 // y => [ 0, 0 ]
 //      [ 1, 1 ]
 
-linspace(ndarray([], [2, 2]), 0, 1, {axis: 1})
+linspace(ndarray([], [2, 2]), 0, 1, {axis: 1});
 // y => [ 0, 1 ]
 //      [ 0, 1 ]
 ```

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,7 +1,8 @@
 'use strict';
 
+var ndarray = require('ndarray');
 var linspace = require('../');
 
-console.log(linspace(2, 3, 10, {endpoint: false}));
+console.log(linspace(ndarray([], [2]), 3, 10, {endpoint: false}));
 
-console.log(linspace(2, 4, 10, {dtype: 'int8'}));
+console.log(linspace(ndarray([], [2]), 4, 10, {dtype: 'int8'}));

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function linspace (output, start, end, options) {
   if (options.endpoint !== undefined && !isbool(options.endpoint)) {
     throw new Error('ndarray-linspace: Endpoint must be a boolean. Got ' + options.endpoint);
   }
-  endpoint = !!(options.endpoint || true);
+  endpoint = options.endpoint === undefined ? true : options.endpoint;
 
   if (options.axis !== undefined && !isnonneg(options.axis)) {
     throw new Error('ndarray-linspace: Axis must be a nonegative integer. Got ' + options.axis);

--- a/test/index.js
+++ b/test/index.js
@@ -34,14 +34,14 @@ describe('linspace', function () {
     });
   });
 
-  it('create a new linspace with and endpoint', function () {
+  it('create a new linspace with an endpoint', function () {
     var x = linspace(ndarray([], [11]), 0, 10);
     var y = ndarray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     assert(ndt.equal(x, y, 1e-8));
   });
 
-  it('create a new linspace without and endpoint', function () {
-    var x = linspace(ndarray([], [10]), 0, 9, {endpoint: false});
+  it('create a new linspace without an endpoint', function () {
+    var x = linspace(ndarray([], [10]), 0, 10, {endpoint: false});
     var y = ndarray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
     assert(ndt.equal(x, y, 1e-8));
   });


### PR DESCRIPTION
Currently, `linspace()` always ends up setting `endpoint` to `true` because of [this line](https://github.com/scijs/ndarray-linspace/blob/3485ab0e6a5ab74e1a97994dce387bd83fa3c3f7/index.js#L24). This PR sets endpoint to whatever was passed in in the `options` object.

I also updated `examples/index.js` and the `{endpoint: false}` example in the README.